### PR TITLE
Issue #80 and related things

### DIFF
--- a/js/src/v8api/object.cpp
+++ b/js/src/v8api/object.cpp
@@ -125,10 +125,6 @@ Object::Set(Handle<Value> key,
     return false;
   }
 
-  // Can't set attributes on indexed properties
-  if (!key->ToUint32().IsEmpty())
-    return true;
-
   uintN js_attribs = 0;
   if (attribs & ReadOnly) {
     js_attribs |= JSPROP_READONLY;

--- a/js/src/v8api/test/Makefile.in
+++ b/js/src/v8api/test/Makefile.in
@@ -15,6 +15,7 @@ CPP_UNIT_TESTS = \
   test_script_run_void.cpp \
   test_String.cpp \
   test_objprop.cpp \
+  test_value.cpp \
   test_trycatch.cpp \
   $(NULL)
 

--- a/js/src/v8api/test/test_api.cpp
+++ b/js/src/v8api/test/test_api.cpp
@@ -4071,7 +4071,37 @@ test_ApplyInterruption()
 // from test-api.cc:9905
 void
 test_ObjectClone()
-{ }
+{
+  v8::HandleScope scope;
+  LocalContext env;
+
+  const char* sample =
+    "var rv = {};"      \
+    "rv.alpha = 'hello';" \
+    "rv.beta = 123;"     \
+    "rv;";
+
+  // Create an object, verify basics.
+  Local<Value> val = CompileRun(sample);
+  CHECK(val->IsObject());
+  Local<v8::Object> obj = val.As<v8::Object>();
+  obj->Set(v8_str("gamma"), v8_str("cloneme"));
+
+  CHECK_EQ(v8_str("hello"), obj->Get(v8_str("alpha")));
+  CHECK_EQ(v8::Integer::New(123), obj->Get(v8_str("beta")));
+  CHECK_EQ(v8_str("cloneme"), obj->Get(v8_str("gamma")));
+
+  // Clone it.
+  Local<v8::Object> clone = obj->Clone();
+  CHECK_EQ(v8_str("hello"), clone->Get(v8_str("alpha")));
+  CHECK_EQ(v8::Integer::New(123), clone->Get(v8_str("beta")));
+  CHECK_EQ(v8_str("cloneme"), clone->Get(v8_str("gamma")));
+
+  // Set a property on the clone, verify each object.
+  clone->Set(v8_str("beta"), v8::Integer::New(456));
+  CHECK_EQ(v8::Integer::New(123), obj->Get(v8_str("beta")));
+  CHECK_EQ(v8::Integer::New(456), clone->Get(v8_str("beta")));
+}
 
 // from test-api.cc:9988
 void
@@ -4822,7 +4852,7 @@ Test gTests[] = {
   UNIMPLEMENTED_TEST(test_CrossContextNew),
   UNIMPLEMENTED_TEST(test_RegExpInterruption),
   UNIMPLEMENTED_TEST(test_ApplyInterruption),
-  UNIMPLEMENTED_TEST(test_ObjectClone),
+  TEST(test_ObjectClone),
   UNIMPLEMENTED_TEST(test_MorphCompositeStringTest),
   UNIMPLEMENTED_TEST(test_CompileExternalTwoByteSource),
   UNIMPLEMENTED_TEST(test_RegExpStringModification),

--- a/js/src/v8api/test/test_api.cpp
+++ b/js/src/v8api/test/test_api.cpp
@@ -4844,7 +4844,7 @@ Test gTests[] = {
   TEST(test_PreCompile),
   TEST(test_PreCompileWithError),
   TEST(test_Regress31661),
-  TEST(test_PreCompileSerialization),
+  DISABLED_TEST(test_PreCompileSerialization, 60),
   TEST(test_PreCompileDeserializationError),
   UNIMPLEMENTED_TEST(test_PreCompileInvalidPreparseDataError),
   UNIMPLEMENTED_TEST(test_PreCompileAPIVariationsAreSame),

--- a/js/src/v8api/test/test_api.cpp
+++ b/js/src/v8api/test/test_api.cpp
@@ -4662,7 +4662,7 @@ Test gTests[] = {
   TEST(test_TryCatchAndFinallyHidingException),
   TEST(test_TryCatchAndFinally),
   TEST(test_Equality),
-  DISABLED_TEST(test_MultiRun, 43),
+  TEST(test_MultiRun),
   TEST(test_SimplePropertyRead),
   DISABLED_TEST(test_DefinePropertyOnAPIAccessor, 83),
   DISABLED_TEST(test_DefinePropertyOnDefineGetterSetter, 84),

--- a/js/src/v8api/test/test_api.cpp
+++ b/js/src/v8api/test/test_api.cpp
@@ -4662,7 +4662,7 @@ Test gTests[] = {
   TEST(test_TryCatchAndFinallyHidingException),
   TEST(test_TryCatchAndFinally),
   TEST(test_Equality),
-  TEST(test_MultiRun),
+  TEST_THROWS(test_MultiRun),
   TEST(test_SimplePropertyRead),
   DISABLED_TEST(test_DefinePropertyOnAPIAccessor, 83),
   DISABLED_TEST(test_DefinePropertyOnDefineGetterSetter, 84),

--- a/js/src/v8api/test/test_api.cpp
+++ b/js/src/v8api/test/test_api.cpp
@@ -4844,7 +4844,7 @@ Test gTests[] = {
   TEST(test_PreCompile),
   TEST(test_PreCompileWithError),
   TEST(test_Regress31661),
-  DISABLED_TEST(test_PreCompileSerialization, 60),
+  TEST(test_PreCompileSerialization),
   TEST(test_PreCompileDeserializationError),
   UNIMPLEMENTED_TEST(test_PreCompileInvalidPreparseDataError),
   UNIMPLEMENTED_TEST(test_PreCompileAPIVariationsAreSame),

--- a/js/src/v8api/test/test_value.cpp
+++ b/js/src/v8api/test/test_value.cpp
@@ -10,8 +10,13 @@ static inline Local<Value> CompileRun(const char* source) {
 ////////////////////////////////////////////////////////////////////////////////
 //// Tests
 
+/*
+ * Most of Value's methods should already be (either implicitly or
+ * explicitly) tested in test_api. The one's that aren't are covered here.
+ */
+
 void
-test_ToInteger()
+test_IntegerConversion()
 {
   HandleScope handle_scope;
   Persistent<Context> context = Context::New();
@@ -19,39 +24,96 @@ test_ToInteger()
 
   // Convert string to Integer.
   Handle<Value> result = CompileRun("'123'");
-  Local<Integer> integer = result->ToInteger();
-  do_check_eq(integer->Value(), 123);
+  do_check_eq(result->IntegerValue(), 123);
+  do_check_eq(result->ToInteger()->Value(), 123);
 
   // Convert integer number to Integer.
   result = CompileRun("123");
-  integer = result->ToInteger();
-  do_check_eq(integer->Value(), 123);
+  do_check_eq(result->IntegerValue(), 123);
+  do_check_eq(result->ToInteger()->Value(), 123);
 
   // Convert decimal number to Integer.
   result = CompileRun("123.45");
-  integer = result->ToInteger();
-  do_check_eq(integer->Value(), 123);
+  do_check_eq(result->IntegerValue(), 123);
+  do_check_eq(result->ToInteger()->Value(), 123);
 
   // Convert negative number to Integer.
   result = CompileRun("-123");
-  integer = result->ToInteger();
-  do_check_eq(integer->Value(), -123);
+  do_check_eq(result->IntegerValue(), -123);
+  do_check_eq(result->ToInteger()->Value(), -123);
 
 /* TODO: we don't support 64 bit numbers yet
 
   // Convert huge number to Integer.
   result = CompileRun("0x7fffffffffffffff");
-  integer = result->ToInteger();
-  do_check_eq(integer->Value(), (JSInt64)0x7fffffffffffffff);
+  do_check_eq(result->IntegerValue(), (JSInt64)0x7fffffffffffffff);
+  do_check_eq(result->ToInteger()->Value(), (JSInt64)0x7fffffffffffffff);
 */
+
+  // Convert NaN to Integer.
+  result = CompileRun("NaN");
+  do_check_eq(result->IntegerValue(), 0);
+  do_check_eq(result->ToInteger()->Value(), 0);
 }
 
+void
+test_BooleanConversion()
+{
+  HandleScope handle_scope;
+  Persistent<Context> context = Context::New();
+  Context::Scope context_scope(context);
+
+  // Convert an a truthy value, e.g. a string, to a boolean.
+  Handle<Value> result = CompileRun("'123'");
+  do_check_true(result->BooleanValue());
+  do_check_true(result->ToBoolean()->Value());
+
+  // Convert an a truthy value, e.g. a string, to a boolean.
+  result = CompileRun("0");
+  do_check_false(result->BooleanValue());
+  do_check_false(result->ToBoolean()->Value());
+}
+
+void
+test_IsFunction()
+{
+  HandleScope handle_scope;
+  Persistent<Context> context = Context::New();
+  Context::Scope context_scope(context);
+
+  // Check something that isn't a function, e.g. a string.
+  Handle<Value> result = CompileRun("'123'");
+  do_check_false(result->IsFunction());
+
+  // Check function.
+  result = CompileRun("function () {}");
+  do_check_true(result->IsFunction());
+}
+
+void
+test_IsArray()
+{
+  HandleScope handle_scope;
+  Persistent<Context> context = Context::New();
+  Context::Scope context_scope(context);
+
+  // Check something that isn't a function, e.g. a string.
+  Handle<Value> result = CompileRun("{}");
+  do_check_false(result->IsArray());
+
+  // Check function.
+  result = CompileRun("[]");
+  do_check_true(result->IsArray());
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 //// Test Harness
 
 Test gTests[] = {
-  TEST(test_ToInteger),
+  TEST(test_IntegerConversion),
+  TEST(test_BooleanConversion),
+  TEST(test_IsFunction),
+  TEST(test_IsArray),
 };
 
 const char* file = __FILE__;

--- a/js/src/v8api/test/test_value.cpp
+++ b/js/src/v8api/test/test_value.cpp
@@ -1,0 +1,60 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+#include "v8api_test_harness.h"
+
+static inline Local<Value> CompileRun(const char* source) {
+  return Script::Compile(String::New(source))->Run();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//// Tests
+
+void
+test_ToInteger()
+{
+  HandleScope handle_scope;
+  Persistent<Context> context = Context::New();
+  Context::Scope context_scope(context);
+
+  // Convert string to Integer.
+  Handle<Value> result = CompileRun("'123'");
+  Local<Integer> integer = result->ToInteger();
+  do_check_eq(integer->Value(), 123);
+
+  // Convert integer number to Integer.
+  result = CompileRun("123");
+  integer = result->ToInteger();
+  do_check_eq(integer->Value(), 123);
+
+  // Convert decimal number to Integer.
+  result = CompileRun("123.45");
+  integer = result->ToInteger();
+  do_check_eq(integer->Value(), 123);
+
+  // Convert negative number to Integer.
+  result = CompileRun("-123");
+  integer = result->ToInteger();
+  do_check_eq(integer->Value(), -123);
+
+/* TODO: we don't support 64 bit numbers yet
+
+  // Convert huge number to Integer.
+  result = CompileRun("0x7fffffffffffffff");
+  integer = result->ToInteger();
+  do_check_eq(integer->Value(), (JSInt64)0x7fffffffffffffff);
+*/
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+//// Test Harness
+
+Test gTests[] = {
+  TEST(test_ToInteger),
+};
+
+const char* file = __FILE__;
+#define TEST_NAME "Value Class"
+#define TEST_FILE file
+#include "v8api_test_harness_tail.h"

--- a/js/src/v8api/test/v8api_test_harness.h
+++ b/js/src/v8api/test/v8api_test_harness.h
@@ -165,12 +165,15 @@ struct Test
   void (*func)(void);
   const char* const name;
   bool disabled;
+  bool throws;
   int issue;
 };
 #define TEST(aName) \
-  {aName, #aName, false, 0}
+  {aName, #aName, false, false, 0}
+#define TEST_THROWS(aName) \
+  {aName, #aName, false, true, 0}
 #define DISABLED_TEST(aName, aIssueNumber) \
-  {aName, #aName, true, aIssueNumber}
+  {aName, #aName, true, false, aIssueNumber}
 #define UNIMPLEMENTED_TEST(aName) \
-  {aName, #aName, true, -1}
+  {aName, #aName, true, false, -1}
 #define UNWANTED_TEST(aName) UNIMPLEMENTED_TEST(aName)

--- a/js/src/v8api/test/v8api_test_harness_tail.h
+++ b/js/src/v8api/test/v8api_test_harness_tail.h
@@ -60,6 +60,9 @@ main(int aArgc,
       (void)printf(TEST_INFO_STR "Running %s.\n", TEST_FILE, test.name);
       TryCatch exceptionHandler;
       test.func();
+      if (!test.throws) {
+        do_check_false(exceptionHandler.HasCaught());
+      }
     }
     else if (test.issue >= 0) {
       do_check_neq(test.issue, 0);

--- a/js/src/v8api/test/v8api_test_harness_tail.h
+++ b/js/src/v8api/test/v8api_test_harness_tail.h
@@ -60,7 +60,6 @@ main(int aArgc,
       (void)printf(TEST_INFO_STR "Running %s.\n", TEST_FILE, test.name);
       TryCatch exceptionHandler;
       test.func();
-      do_check_false(exceptionHandler.HasCaught());
     }
     else if (test.issue >= 0) {
       do_check_neq(test.issue, 0);

--- a/js/src/v8api/v8.cpp
+++ b/js/src/v8api/v8.cpp
@@ -297,10 +297,6 @@ Local<Uint32> Value::ToUint32() const {
     TryCatch::CheckForException();
     return Local<Uint32>();
   }
-  // XXX this is somehow still needed to make test_PropertyAttributes pass.
-  if (!IsNumber()) {
-    return Local<Uint32>();
-  }
   Uint32 v(i);
   return Local<Uint32>::New(&v);
 }

--- a/js/src/v8api/v8.cpp
+++ b/js/src/v8api/v8.cpp
@@ -318,6 +318,10 @@ Local<Int32> Value::ToInt32() const {
 Local<Integer>
 Value::ToInteger() const
 {
+  if (JSVAL_IS_INT(mVal)) {
+    return Integer::New(JSVAL_TO_INT(mVal));
+  }
+
   // TODO should be supporting 64bit wide ints here
   JSInt32 i;
   if (!JS_ValueToECMAInt32(cx(), mVal, &i)) {
@@ -406,7 +410,7 @@ JSInt64
 Value::IntegerValue() const
 {
   // There are no 64 bit integers, so just return the 32bit one
-  if (JSVAL_IS_INT(mVal) == JS_TRUE) {
+  if (JSVAL_IS_INT(mVal)) {
     return JSVAL_TO_INT(mVal);
   }
 


### PR DESCRIPTION
Thought I'd finally finish #80:
- short-circuit integers in Value::ToInteger()
- fix the bogus IsNumber() check in Value::ToUint32()

In the process I've tried to make sure the To_() and Is_() methods have appropriate test coverage. Some by adding + enabling existing v8 api tests, some by writing my own in test_value.cpp, some by enabling previously disabled tests.

One of those tests is test_MultiRun (cf. issue #43): our test harness assumes that v8 tests never leave an exception on the JS stack. That's clearly not the case with test_MultiRun, so I got rid of that check.
